### PR TITLE
Use RAII for timing scopes instead of error-prone push-pop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Adding new features, improving documentation, fixing bugs, writing new tests,
 designing and coding new examples or writing tutorials are all examples of 
 helpful contributions.
 
-## Prerequisits
+## Prerequisites
 All the prerequisites for contributions are already installed in every Docker 
 container. They include C++ compiler and linker, cmake, clang-format, git tools,
 editors, plus the IBM HElib and its dependencies.

--- a/DEPENDENCIES/simple_ml_helib/src/CipherMatrix.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/CipherMatrix.cpp
@@ -32,22 +32,20 @@ CipherMatrix::CipherMatrix(const CTile& prototype) : prototype(prototype), numFi
 }
 
 CipherMatrix::CipherMatrix(const CipherMatrix& src) : prototype(src.prototype), numFilledSlots(src.numFilledSlots) {
-	SimpleTimer::push("CipherMatrix::copy");
+	SimpleTimer::Guard guard("CipherMatrix::copy");
 
 	tiles.reshape(src.tiles.extents(), prototype);
 	for(int i=0; i<tiles.size(); ++i)
 		tiles[i] = CTile(src.tiles[i]);
-
-	SimpleTimer::pop();
 }
 
 CipherMatrix::~CipherMatrix(){
 }
 
 streamoff CipherMatrix::save(ostream& stream) const {
-	SimpleTimer::push("CipherMatrix::save");
+  SimpleTimer::Guard guard("CipherMatrix::save");
 
-  streampos streamStartPos = stream.tellp();
+  const streampos streamStartPos = stream.tellp();
 
   int numRows = tiles.size(0);
   int numCols = tiles.size(1);
@@ -61,16 +59,15 @@ streamoff CipherMatrix::save(ostream& stream) const {
       tiles.at(i,j).save(stream);
   }
 
-  streampos streamEndPos = stream.tellp();
+  const streampos streamEndPos = stream.tellp();
 
-	SimpleTimer::pop();
   return streamEndPos - streamStartPos;
 }
 
 streamoff CipherMatrix::load(istream& stream){
-	SimpleTimer::push("CipherMatrix::load");
+  SimpleTimer::Guard guard("CipherMatrix::load");
 
-  streampos streamStartPos = stream.tellg();
+  const streampos streamStartPos = stream.tellg();
 
   int numRows, numCols;
 
@@ -86,14 +83,13 @@ streamoff CipherMatrix::load(istream& stream){
       tiles.at(i,j).load(stream);
   }
 
-  streampos streamEndPos = stream.tellg();
+  const streampos streamEndPos = stream.tellg();
 
-	SimpleTimer::pop();
   return streamEndPos - streamStartPos;
 }
 
 void CipherMatrix::add(const CipherMatrix& other){
-	SimpleTimer::push("CipherMatrix::add");
+	SimpleTimer::Guard guard("CipherMatrix::add");
 
 	if(tiles.size(0) != other.tiles.size(0) || tiles.size(1) != other.tiles.size(1) ||
 			numFilledSlots != other.numFilledSlots)
@@ -101,12 +97,10 @@ void CipherMatrix::add(const CipherMatrix& other){
 
 	for(int i=0; i<tiles.size(); ++i)
 		tiles[i].add(other.tiles[i]);
-
-	SimpleTimer::pop();
 }
 
 CipherMatrix CipherMatrix::getMatrixMultiply(const CipherMatrix& other) const {
-	SimpleTimer::push("CipherMatrix::getMatrixMultiply");
+	SimpleTimer::Guard guard("CipherMatrix::getMatrixMultiply");
 
 	if(tiles.size(1) != other.tiles.size(0) || numFilledSlots != other.numFilledSlots)
 		throw invalid_argument("Other has incompatible dimensions");
@@ -133,17 +127,14 @@ CipherMatrix CipherMatrix::getMatrixMultiply(const CipherMatrix& other) const {
 	res.relinearize();
 	res.rescale();
 
-	SimpleTimer::pop();
 	return res;
 }
 
 void CipherMatrix::square(){
-	SimpleTimer::push("CipherMatrix::square");
+  SimpleTimer::Guard guard("CipherMatrix::square");
 
   for(auto& tile:tiles)
     tile.square();
-
-	SimpleTimer::pop();
 }
 
 CipherMatrix CipherMatrix::getSquare() const {
@@ -153,21 +144,17 @@ CipherMatrix CipherMatrix::getSquare() const {
 }
 
 void CipherMatrix::relinearize(){
-	SimpleTimer::push("CipherMatrix::relinearize");
+  SimpleTimer::Guard guard("CipherMatrix::relinearize");
 
   for(auto& tile:tiles)
     tile.relinearize();
-
-	SimpleTimer::pop();
 }
 
 void CipherMatrix::rescale(){
-	SimpleTimer::push("CipherMatrix::rescale");
+  SimpleTimer::Guard guard("CipherMatrix::rescale");
 
   for(auto& tile:tiles)
     tile.rescale();
-
-	SimpleTimer::pop();
 }
 
 int CipherMatrix::getChainIndex() const {

--- a/DEPENDENCIES/simple_ml_helib/src/CipherMatrixEncoder.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/CipherMatrixEncoder.cpp
@@ -36,7 +36,7 @@ CipherMatrixEncoder::~CipherMatrixEncoder(){
 
 void CipherMatrixEncoder::encodeEncrypt(CipherMatrix& res, const tensor<double>& vals,
 		int chainIndex) const {
-	SimpleTimer::push("CipherMatrixEncoder::encodeEncrypt");
+	SimpleTimer::Guard guard("CipherMatrixEncoder::encodeEncrypt");
 
 	if(vals.order() != 3)
 		throw invalid_argument("Input must be 3-dimensional tensor");
@@ -60,8 +60,6 @@ void CipherMatrixEncoder::encodeEncrypt(CipherMatrix& res, const tensor<double>&
   }
 
   res.numFilledSlots = numFilledSlots;
-
-	SimpleTimer::pop();
 }
 
 void CipherMatrixEncoder::encodeEncrypt(CipherMatrix& res, const tensor<complex<double>>& vals,
@@ -70,7 +68,7 @@ void CipherMatrixEncoder::encodeEncrypt(CipherMatrix& res, const tensor<complex<
 }
 
 tensor<double> CipherMatrixEncoder::decryptDecodeDouble(const CipherMatrix& src) const {
-	SimpleTimer::push("CipherMatrixEncoder::decryptDecodeDouble");
+  SimpleTimer::Guard guard("CipherMatrixEncoder::decryptDecodeDouble");
 
   int numRows = src.tiles.size(0);
   int numCols = src.tiles.size(1);
@@ -86,8 +84,7 @@ tensor<double> CipherMatrixEncoder::decryptDecodeDouble(const CipherMatrix& src)
     }
   }
 
-	SimpleTimer::pop();
-	return res;
+  return res;
 }
 
 tensor<complex<double>> CipherMatrixEncoder::decryptDecodeComplex(const CipherMatrix& src) const {

--- a/DEPENDENCIES/simple_ml_helib/src/SimpleFcLayer.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/SimpleFcLayer.cpp
@@ -37,35 +37,33 @@ SimpleFcLayer::~SimpleFcLayer(){
 }
 
 streamoff SimpleFcLayer::save(ostream& stream) const {
-	SimpleTimer::push("SimpleFcLayer::save");
+  SimpleTimer::Guard guard("SimpleFcLayer::save");
 
-  streampos streamStartPos = stream.tellp();
+  const streampos streamStartPos = stream.tellp();
 
   weights.save(stream);
   bias.save(stream);
 
-  streampos streamEndPos = stream.tellp();
+  const streampos streamEndPos = stream.tellp();
 
-	SimpleTimer::pop();
   return streamEndPos - streamStartPos;
 }
 
 streamoff SimpleFcLayer::load(istream& stream){
-	SimpleTimer::push("SimpleFcLayer::load");
+  SimpleTimer::Guard guard("SimpleFcLayer::load");
 
-  streampos streamStartPos = stream.tellg();
+  const streampos streamStartPos = stream.tellg();
 
   weights.load(stream);
   bias.load(stream);
 
-  streampos streamEndPos = stream.tellg();
+  const streampos streamEndPos = stream.tellg();
 
-	SimpleTimer::pop();
   return streamEndPos - streamStartPos;
 }
 
 void SimpleFcLayer::initFromLayer(const FcPlainLayer& fpl, int baseChainIndex){
-	SimpleTimer::push("SimpleFcLayer::initFromLayer");
+	SimpleTimer::Guard guard("SimpleFcLayer::initFromLayer");
 
 	if(!he.automaticallyManagesChainIndices()){
 		if(baseChainIndex < -1 || baseChainIndex > he.getTopChainIndex())
@@ -80,16 +78,13 @@ void SimpleFcLayer::initFromLayer(const FcPlainLayer& fpl, int baseChainIndex){
   const CipherMatrixEncoder encoder(he);
   encoder.encodeEncrypt(weights, weightsVals, baseChainIndex);
   encoder.encodeEncrypt(bias, biasVals, baseChainIndex - 1);
-
-  SimpleTimer::pop();
 }
 
 CipherMatrix SimpleFcLayer::forward(const CipherMatrix& inVec) const {
-	SimpleTimer::push("SimpleFcLayer::forward");
+	SimpleTimer::Guard guard("SimpleFcLayer::forward");
 
 	CipherMatrix res = weights.getMatrixMultiply(inVec);
 	res.add(bias);
 
-  SimpleTimer::pop();
 	return res;
 }

--- a/DEPENDENCIES/simple_ml_helib/src/SimpleSquareActivationLayer.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/SimpleSquareActivationLayer.cpp
@@ -34,10 +34,9 @@ SimpleSquareActivationLayer::~SimpleSquareActivationLayer(){
 }
 
 CipherMatrix SimpleSquareActivationLayer::forward(const CipherMatrix& inVec) const {
-	SimpleTimer::push("SimpleSquareActivationLayer::forward");
+	SimpleTimer::Guard guard("SimpleSquareActivationLayer::forward");
 
 	CipherMatrix res = inVec.getSquare();
 
-  SimpleTimer::pop();
 	return res;
 }


### PR DESCRIPTION
Why?
1. It is easy to forget `pop()` call, so timing values may be missed.
2. Reduce src size, so the bugs probability.

Also fix small typo in CONTRIBUTING.md