### PR TITLE
Fix some simple ml helib compiler warnings

### DIFF
--- a/DEPENDENCIES/simple_ml_helib/src/AbstractCiphertext.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/AbstractCiphertext.cpp
@@ -142,7 +142,7 @@ double AbstractCiphertext::assertEquals(const std::string& title, const std::vec
   	throw runtime_error("Size of expected values vector is bigger than size of cipher");
 
   double maxDiff = 0;
-  for(int i=0; i<expectedVals.size(); ++i){
+  for(size_t i=0; i<expectedVals.size(); ++i){
   	double diff = abs(vals[i] - expectedVals[i]);
   	double relDiff;
   	if (vals[i]!=0)

--- a/DEPENDENCIES/simple_ml_helib/src/HeContext.h
+++ b/DEPENDENCIES/simple_ml_helib/src/HeContext.h
@@ -26,6 +26,7 @@
 #define SRC_ML_HE_EXAMPLES_HECONTEXT_H
 
 #include <memory>
+#include <string>
 
 class AbstractCiphertext;
 class AbstractPlaintext;

--- a/DEPENDENCIES/simple_ml_helib/src/SimpleTimer.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/SimpleTimer.cpp
@@ -61,7 +61,7 @@ SimpleTimer::SectionInfo& SimpleTimer::SectionInfo::getSubSection(
 
 SimpleTimer::SectionInfo& SimpleTimer::SectionInfo::find(
     const std::string& title, const std::string& prefix) {
-  if (title == "")
+  if (title.empty())
     return *this;
 
   size_t p = title.find('.');

--- a/DEPENDENCIES/simple_ml_helib/src/SimpleTimer.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/SimpleTimer.cpp
@@ -134,14 +134,14 @@ void SimpleTimer::stop() {
 void SimpleTimer::SectionInfo::addMeasure(
     std::chrono::high_resolution_clock::time_point s, int64_t cpu_s) {
   auto end_time = high_resolution_clock::now();
-  int mircosecs = duration_cast<microseconds>(end_time - s).count();
+  int64_t microsecs = duration_cast<microseconds>(end_time - s).count();
 
   auto end_cpu = getProcessCPUTime();
   int64_t cpu_microsecs = (end_cpu - cpu_s) / 1000;
 
   const lock_guard<mutex> lock(mtx);
-  sum += mircosecs;
-  sumSquares += mircosecs * mircosecs;
+  sum += microsecs;
+  sumSquares += microsecs * microsecs;
   count += 1;
   sumCPU += cpu_microsecs;
 }

--- a/DEPENDENCIES/simple_ml_helib/src/SimpleTimer.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/SimpleTimer.cpp
@@ -64,7 +64,7 @@ SimpleTimer::SectionInfo& SimpleTimer::SectionInfo::find(
   if (title == "")
     return *this;
 
-  int p = title.find('.');
+  size_t p = title.find('.');
   string key = title;
   string cont = "";
 

--- a/DEPENDENCIES/simple_ml_helib/src/SimpleTimer.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/SimpleTimer.cpp
@@ -64,7 +64,7 @@ SimpleTimer::SectionInfo& SimpleTimer::SectionInfo::find(
   if (title == "")
     return *this;
 
-  int p = title.find(".");
+  int p = title.find('.');
   string key = title;
   string cont = "";
 

--- a/DEPENDENCIES/simple_ml_helib/src/h5Dumper.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/h5Dumper.cpp
@@ -56,7 +56,7 @@ void H5Dumper::setLayerNames(const vector<string>& layerNames)
   StrType strDataType(PredType::C_S1, H5T_VARIABLE);
   vector<const char*> layerNamesCStr(layerNames.size());
 
-  for(int i = 0; i < layerNames.size(); i++)
+  for(size_t i = 0; i < layerNames.size(); i++)
   {
     layerNamesCStr[i] = layerNames[i].c_str();
   }
@@ -83,7 +83,7 @@ void H5Dumper::setLayerWeightNames(const string& layerName,
   StrType strDataType(PredType::C_S1, H5T_VARIABLE);
   vector<const char*> weightNamesCStr(weightNames.size());
 
-  for(int i = 0; i < weightNames.size(); i++)
+  for(size_t i = 0; i < weightNames.size(); i++)
   {
     weightNamesCStr[i] = weightNames[i].c_str();
   }

--- a/DEPENDENCIES/simple_ml_helib/src/h5Dumper.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/h5Dumper.cpp
@@ -29,8 +29,7 @@
 using namespace std;
 using namespace H5;
 
-H5Dumper::H5Dumper(const string& f) {
-  this->file_name = f;
+H5Dumper::H5Dumper(const string& f) : file_name(f) {
   file = H5File(f, H5F_ACC_TRUNC);
 }
 

--- a/DEPENDENCIES/simple_ml_helib/src/h5Parser.cpp
+++ b/DEPENDENCIES/simple_ml_helib/src/h5Parser.cpp
@@ -43,9 +43,7 @@ bool H5Parser::objectExists(const string& name) const {
   }
 }
 
-H5Parser::H5Parser(string f) {
-  this->file_name = f;
-
+H5Parser::H5Parser(string f) : file_name(f) {
   // test file exists, for a nicer error message
   ifstream test(f);
   if (!test.good())


### PR DESCRIPTION
Just fix some common compiler warnings:
* signed | unsigned arithmetic mix.
* implicit signed values truncation (`int64_t` -> `int`).
* compute timer measure interval correctly when elapsed microseconds > `INT_MAX`.
* small performance improvements.