### PR TITLE
Include full path to .csv file in country look up demo

### DIFF
--- a/samples/BGV_country_db_lookup/BGV_country_db_lookup.cpp
+++ b/samples/BGV_country_db_lookup/BGV_country_db_lookup.cpp
@@ -88,7 +88,7 @@ int main(int argc, char* argv[])
   // Size of NTL thread pool (default =1)
   unsigned long nthreads = 1;
   // input database file name
-  std::string db_filename="./examples/BGV_country_db_lookup/countries_dataset.csv";
+  std::string db_filename="/opt/IBM/FHE-Workspace/examples/BGV_country_db_lookup/countries_dataset.csv";
   // debug output (default no debug output)
   bool debug = false;
 


### PR DESCRIPTION
A recent change in cmake-tools means that the launch directory is now set to ./build. This causes the country demo to fail locating the `countries_dataset.csv` as it uses a relative.

https://github.com/microsoft/vscode-cmake-tools/issues/1395

 #40 