### PR TITLE
Rollback cpptools version to v0.29.0 - amd64 arch Fedora, Ubuntu, Centos

### DIFF
--- a/Dockerfile.CENTOS-amd64.Toolkit
+++ b/Dockerfile.CENTOS-amd64.Toolkit
@@ -36,7 +36,7 @@ RUN cp -rp /opt/IBM/FHE-distro/HElib/examples /opt/IBM/FHE-Workspace
 COPY --chown=fhe:fhe ./samples/ /opt/IBM/FHE-Workspace/examples/
 
 # Install code-server extensions
-RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cpptools --force
+RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cpptools@0.29.0 --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cmake-tools --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension twxs.cmake --force
 # set code-server to create a self signed cert

--- a/Dockerfile.FEDORA-amd64.Toolkit
+++ b/Dockerfile.FEDORA-amd64.Toolkit
@@ -36,7 +36,7 @@ RUN cp -rp /opt/IBM/FHE-distro/HElib/examples /opt/IBM/FHE-Workspace
 COPY --chown=fhe:fhe ./samples/ /opt/IBM/FHE-Workspace/examples/
 
 # Install code-server extensions
-RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cpptools --force
+RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cpptools@0.29.0 --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cmake-tools --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension twxs.cmake --force
 # set code-server to create a self signed cert

--- a/Dockerfile.UBUNTU-amd64.Toolkit
+++ b/Dockerfile.UBUNTU-amd64.Toolkit
@@ -39,7 +39,7 @@ RUN cp -rp /opt/IBM/FHE-distro/HElib/examples /opt/IBM/FHE-Workspace
 COPY --chown=fhe:fhe ./samples/ /opt/IBM/FHE-Workspace/examples/
 
 # Install code-server extensions
-RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cpptools --force
+RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cpptools@0.29.0 --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cmake-tools --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension twxs.cmake --force
 # set code-server to create a self signed cert


### PR DESCRIPTION
#42 