### PR TITLE
Slack Notification Fixes

### DIFF
--- a/scripts/jenkins/fhe_artifactory_notification_script.sh
+++ b/scripts/jenkins/fhe_artifactory_notification_script.sh
@@ -8,10 +8,10 @@ COMMIT_URL=""
 
 generate_post_message()
 {
-  cat <<EOF
-{
-  "text":"A new build of $BUILD_KIND for $BUILD_TYPE based on GitHub commit: <$COMMIT_URL|$COMMIT_NUMBER>, passed all the tests and is now available for docker pull at <$ARTE_URL>"
-}
+ cat <<EOF
+ {
+  "text":"A new build of $BUILD_KIND for $BUILD_TYPE based on GitHub commit: <$COMMIT_URL|$COMMIT_NUMBER >, passed all the tests and is now available for docker pull at <$ARTE_URL>"
+ }
 EOF
 }
 
@@ -19,7 +19,7 @@ get_commit_url()
 {
   #Make HTTPS
   SUFFIX=".git"
-  BASE_URL=$(git config --get remote.origin.url | sed -e 's/:/\//g'| sed -e 's/git@/https:\/\//g')
+  BASE_URL="https://github.com/IBM/fhe-toolkit-linux"
   GIT_BASE=${BASE_URL%"$SUFFIX"}
   origin_head=$(git ls-remote --heads $(git config --get remote.origin.url) | grep "refs/heads/master" | cut -f 1)
   COMMIT_URL=$GIT_BASE"/commit/$origin_head"

--- a/scripts/jenkins/fhe_docker_jenkins_trigger_builds_alpine.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_trigger_builds_alpine.sh
@@ -90,4 +90,4 @@ fi
 
 #Make A Notification in the Slack Channel about a new artifact in the repo
 pushd scripts/jenkins
-./fhe_artifactory_notification_script.sh $SLACK_HOOK "UBUNTU" $BUILD_TYPE $ARTE_URL
+./fhe_artifactory_notification_script.sh $SLACK_HOOK "Alpine" $BUILD_TYPE $ARTE_URL

--- a/scripts/jenkins/fhe_docker_jenkins_trigger_builds_centos.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_trigger_builds_centos.sh
@@ -74,4 +74,4 @@ BUILD_TYPE="amd64"
 
 #Make A Notification in the Slack Channel about a new artifact in the repo
 pushd scripts/jenkins
-./fhe_artifactory_notification_script.sh $SLACK_HOOK "UBUNTU" $BUILD_TYPE $ARTE_URL
+./fhe_artifactory_notification_script.sh $SLACK_HOOK "CentOS" $BUILD_TYPE $ARTE_URL

--- a/scripts/jenkins/fhe_docker_jenkins_trigger_builds_fedora.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_trigger_builds_fedora.sh
@@ -88,4 +88,4 @@ fi
 
 #Make A Notification in the Slack Channel about a new artifact in the repo
 pushd scripts/jenkins
-./fhe_artifactory_notification_script.sh $SLACK_HOOK "UBUNTU" $BUILD_TYPE $ARTE_URL
+./fhe_artifactory_notification_script.sh $SLACK_HOOK "Fedora" $BUILD_TYPE $ARTE_URL

--- a/scripts/jenkins/fhe_docker_jenkins_trigger_builds_ubuntu.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_trigger_builds_ubuntu.sh
@@ -92,6 +92,6 @@ fi
 
 #Make A Notification in the Slack Channel about a new artifact in the repo
 pushd scripts/jenkins
-./fhe_artifactory_notification_script.sh $SLACK_HOOK "UBUNTU" $BUILD_TYPE $ARTE_URL
+./fhe_artifactory_notification_script.sh $SLACK_HOOK "Ubuntu" $BUILD_TYPE $ARTE_URL
 
 


### PR DESCRIPTION
fixed the url building for the commit number link.  Also, fixing the hardcoding of Ubuntu as the version everywhere to be displayed in the slack channel