### PR TITLE
Cpptools issues amd64 Arch

### DIFF
--- a/Dockerfile.ALPINE-amd64.Toolkit
+++ b/Dockerfile.ALPINE-amd64.Toolkit
@@ -21,6 +21,8 @@ RUN apk add --no-cache openssl python3 pkgconfig xterm libx11-dev libxkbfile-dev
 RUN yarn global add node-gyp 
 RUN yarn global add node-pty 
 RUN yarn global add code-server
+#Install cpptools from the latest vsix version which we are pinning to becuase we have issues getting it to install normally - 12.03.2020 - greg
+ADD https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix /opt/IBM/FHE-Workspace/
 
 # Create a directory to hold the VSCode user data when running as root
 RUN mkdir -p /opt/IBM/IDE-Data
@@ -43,7 +45,9 @@ RUN cp -rp /opt/IBM/FHE-distro/HElib/examples /opt/IBM/FHE-Workspace
 COPY --chown=fhe:fhe ./samples/ /opt/IBM/FHE-Workspace/examples/
 
 # Install VSCode extensions
-RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cpptools@0.29.0 --force
+#We are installing the cpptools from a specific vsix version manually because it fails to install the traditional way. This version is 1.1.2 which is the latest at this time 12.02.2020 - greg 
+#https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix
+RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension /opt/IBM/FHE-Workspace/cpptools-linux.vsix --force; exit 0
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cmake-tools --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension twxs.cmake --force
 

--- a/Dockerfile.CENTOS-amd64.Toolkit
+++ b/Dockerfile.CENTOS-amd64.Toolkit
@@ -16,6 +16,8 @@ WORKDIR /root
 
 # Install code-server so we can access the IDE from a container context...
 RUN curl -fsSL https://code-server.dev/install.sh | sh 2>&1
+#Install cpptools from the latest vsix version which we are pinning to becuase we have issues getting it to install normally - 12.03.2020 - greg
+ADD https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix /opt/IBM/FHE-Workspace/
 
 # Create a directory to hold the VSCode user data
 RUN mkdir -p /opt/IBM/IDE-Data
@@ -38,7 +40,9 @@ RUN cp -rp /opt/IBM/FHE-distro/HElib/examples /opt/IBM/FHE-Workspace
 COPY --chown=fhe:fhe ./samples/ /opt/IBM/FHE-Workspace/examples/
 
 # Install code-server extensions
-RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cpptools@0.29.0 --force
+#We are installing the cpptools from a specific vsix version manually because it fails to install the traditional way. This version is 1.1.2 which is the latest at this time 12.02.2020 - greg 
+#https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix
+RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension /opt/IBM/FHE-Workspace/cpptools-linux.vsix --force; exit 0
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cmake-tools --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension twxs.cmake --force
 # set code-server to create a self signed cert

--- a/Dockerfile.FEDORA-amd64.Toolkit
+++ b/Dockerfile.FEDORA-amd64.Toolkit
@@ -16,6 +16,8 @@ WORKDIR /root
 
 # Install code-server so we can access the IDE from a container context...
 RUN curl -fsSL https://code-server.dev/install.sh | sh 2>&1
+#Install cpptools from the latest vsix version which we are pinning to becuase we have issues getting it to install normally - 12.03.2020 - greg
+ADD https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix /opt/IBM/FHE-Workspace/
 
 # Create a directory to hold the VSCode user data
 RUN mkdir -p /opt/IBM/IDE-Data
@@ -38,7 +40,9 @@ RUN cp -rp /opt/IBM/FHE-distro/HElib/examples /opt/IBM/FHE-Workspace
 COPY --chown=fhe:fhe ./samples/ /opt/IBM/FHE-Workspace/examples/
 
 # Install code-server extensions
-RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cpptools@0.29.0 --force
+#We are installing the cpptools from a specific vsix version manually because it fails to install the traditional way. This version is 1.1.2 which is the latest at this time 12.02.2020 - greg 
+#https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix
+RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension /opt/IBM/FHE-Workspace/cpptools-linux.vsix --force; exit 0
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cmake-tools --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension twxs.cmake --force
 # set code-server to create a self signed cert

--- a/Dockerfile.UBUNTU-amd64.Toolkit
+++ b/Dockerfile.UBUNTU-amd64.Toolkit
@@ -39,9 +39,11 @@ RUN cp -rp /opt/IBM/FHE-distro/HElib/examples /opt/IBM/FHE-Workspace
 
 # Copy over additional examples into the FHE-Workspace from the github checkout on this host
 COPY --chown=fhe:fhe ./samples/ /opt/IBM/FHE-Workspace/examples/
+COPY --chown=fhe:fhe cpptools-linux.vsix /opt/IBM/FHE-Workspace/cpptools.vsix
 
 # Install code-server extensions
-RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cpptools@0.29.0 --force
+#We are installing the cpptools from a specific vsix version manually because it fails to install the other way. This version is 1.1.2 
+RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension /opt/IBM/FHE-Workspace/cpptools.vsix --force; exit 0
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cmake-tools --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension twxs.cmake --force
 # set code-server to create a self signed cert

--- a/Dockerfile.UBUNTU-amd64.Toolkit
+++ b/Dockerfile.UBUNTU-amd64.Toolkit
@@ -43,6 +43,7 @@ COPY --chown=fhe:fhe cpptools-linux.vsix /opt/IBM/FHE-Workspace/cpptools.vsix
 
 # Install code-server extensions
 #We are installing the cpptools from a specific vsix version manually because it fails to install the other way. This version is 1.1.2 
+#https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension /opt/IBM/FHE-Workspace/cpptools.vsix --force; exit 0
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cmake-tools --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension twxs.cmake --force

--- a/Dockerfile.UBUNTU-amd64.Toolkit
+++ b/Dockerfile.UBUNTU-amd64.Toolkit
@@ -19,6 +19,8 @@ RUN export DEBIAN_FRONTEND=noninteractive
 
 # Install code-server so we can access the IDE from a container context...
 RUN curl -fsSL https://code-server.dev/install.sh | sh
+#Install cpptools from the latest vsix version which we are pinning to becuase we have issues getting it to install normally - 12.03.2020 - greg
+ADD https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix /opt/IBM/FHE-Workspace/
 
 # Create a directory to hold the VSCode user data
 RUN mkdir -p /opt/IBM/IDE-Data
@@ -42,9 +44,10 @@ COPY --chown=fhe:fhe ./samples/ /opt/IBM/FHE-Workspace/examples/
 COPY --chown=fhe:fhe cpptools-linux.vsix /opt/IBM/FHE-Workspace/cpptools.vsix
 
 # Install code-server extensions
-#We are installing the cpptools from a specific vsix version manually because it fails to install the other way. This version is 1.1.2 
+#We are installing the cpptools from a specific vsix version manually because it fails to install the traditional way. This version is 1.1.2 which is the latest at this time 12.02.2020 - greg 
 #https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix
-RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension /opt/IBM/FHE-Workspace/cpptools.vsix --force; exit 0
+RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension /opt/IBM/FHE-Workspace/cpptools-linux.vsix --force; exit 0
+#RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension /opt/IBM/FHE-Workspace/cpptools.vsix --force; exit 0
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension ms-vscode.cmake-tools --force
 RUN code-server --user-data-dir=/opt/IBM/IDE-Data/ --install-extension twxs.cmake --force
 # set code-server to create a self signed cert


### PR DESCRIPTION
This has been a bug for a while now, we have been installing the cpptools plugin ms-vscode.cpptools directly as per the instructions but it has been failing to install.  Our workaround was to rollback to version 0.29 (currently they are up to 1.1.2), as that was the last version that was working with that method of installation.  Recently that version started to fail to install as well.  

The answer is to load the plugin as a .vsix file that we obtain directly from Microsoft's GitHub repo [https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix](https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix).  We can then call install-extension and it will successfully install.  The caveat for that is after install it will throw a generic 500 error.  We tell Docker to ignore that error for now (temp workaround), and everything continues to run.

This has been altered on ubuntu, fedora, centos, and alpine amd64 arch.  Separate PR for s390 arch in the near future