### PR TITLE
Jenkins make docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
+    "git.ignoreLimitWarning": true
 
 }

--- a/DEPENDENCIES/ML-HElib/src/helayers/hebase/AlwaysAssert.cpp
+++ b/DEPENDENCIES/ML-HElib/src/helayers/hebase/AlwaysAssert.cpp
@@ -29,7 +29,6 @@
 
 using namespace std;
 
-#ADD A TEST LINE TO SEE IF IT WILL TRIGGER A DOC GENERATION
 
 namespace helayers {
 

--- a/DEPENDENCIES/ML-HElib/src/helayers/hebase/AlwaysAssert.cpp
+++ b/DEPENDENCIES/ML-HElib/src/helayers/hebase/AlwaysAssert.cpp
@@ -29,6 +29,8 @@
 
 using namespace std;
 
+#ADD A TEST LINE TO SEE IF IT WILL TRIGGER A DOC GENERATION
+
 namespace helayers {
 
 void always_assert_fail(const char* conditionString,

--- a/scripts/docs/WriteMLHElibAPIDocs.sh
+++ b/scripts/docs/WriteMLHElibAPIDocs.sh
@@ -92,7 +92,7 @@ done
 
 # The default location on this host where the project docs will live
 DOCS_BASE_PATH="$PWD"/Documentation/docs
-DOCS_HELIB_PATH="$DOCS_BASE_PATH/ml-helib"
+
 
 # Since we have one parameter, let's initialize the container image
 ToolkitImageName=$1
@@ -104,6 +104,9 @@ then
   print_usage
   exit -3
 fi
+
+DOCS_BASE_PATH=$2
+DOCS_HELIB_PATH="$DOCS_BASE_PATH/ml-helib"
 
 echo "Creating Documentation and adding it Locally: ${DOCS_BASE_PATH}"
   if ! mkdir -p "$DOCS_HELIB_PATH/"

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -30,21 +30,35 @@ set -x
 set -u
 set -e
 
-#Remove any previous lingering files from the last build
+
+#Remove any previous lingering files from the last build in case it wasn't removed
 if [ -d "fhe-toolkit-linux" ]; then
     rm -rf fhe-toolkit-linux
 fi
 
-# Checkout specifically the gh-pages branch, so we can push our docs to it
-git clone -b gh-pages --single-branch git@github.com:IBM/fhe-toolkit-linux.git
-ls
-cd fhe-toolkit-linux
-#Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
-./RenderMLhelibAPI.sh local/fhe-toolkit-ubuntu html
+H_FILES='.h'
+CPP_FILES='.cpp'
+GIT_LOG=$(git log --since="24 hours ago" --name-only)
+echo $GIT_LOG
 
-git add --all
-git commit -m "test commit for docs"
-git push origin gh-pages
-pushd ../
-pwd
-rm -rf fhe-toolkit-linux
+#Check to see if the .h files or the .cpp files were changed recently otherwise do nothing
+if [[ "$GIT_LOG" == *"$H_FILES"* || "$GIT_LOG" == *"$CPP_FILES"* ]; then 
+    echo "CHANGES WERE MADE SO RE-GENERATE THE DOCS"
+    # Checkout specifically the gh-pages branch, so we can push our docs to it
+    git clone -b gh-pages --single-branch git@github.com:IBM/fhe-toolkit-linux.git
+
+    cd fhe-toolkit-linux
+    #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
+    ./RenderMLhelibAPI.sh local/fhe-toolkit-ubuntu html
+
+    git add --all
+    git commit -m "test commit for docs"
+    git push origin gh-pages
+    pushd ../
+    pwd
+    rm -rf fhe-toolkit-linux
+fi
+
+
+
+

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -1,0 +1,36 @@
+#/bin/bash 
+
+
+# MIT License
+# 
+# Copyright (c) 2020 International Business Machines
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Navigate to the top level of the Repo
+pushd ../docs
+set -x 
+set -u
+set -e
+
+# Checkout specifically the gh-pages branch, so we can push our docs to it
+git checkout gh-pages
+
+#Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
+./WriteMLHElibAPIDocs local/fhe-toolkit-ubuntu ./html

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -30,6 +30,11 @@ set -x
 set -u
 set -e
 
+#Remove any previous lingering files from the last build
+if [ -d "fhe-toolkit-linux" ]; then
+    rm -rf fhe-toolkit-linux
+fi
+
 # Checkout specifically the gh-pages branch, so we can push our docs to it
 git clone -b gh-pages --single-branch git@github.com:IBM/fhe-toolkit-linux.git
 ls

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -33,4 +33,4 @@ set -e
 git checkout gh-pages
 
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
-git restore master WriteMLHElibAPIDocs local/fhe-toolkit-ubuntu ./html
+git restore jenkins-make-docs WriteMLHElibAPIDocs local/fhe-toolkit-ubuntu ./html

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -37,4 +37,9 @@ cd fhe-toolkit-linux
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
 ./RenderMLhelibAPI.sh local/fhe-toolkit-ubuntu html
 
-#git checkout jenkins-make-docs
+git add --all
+git commit -m "test commit for docs"
+git push origin gh-pages
+pushd ../
+pwd
+rm -rf fhe-toolkit-linux

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -33,6 +33,7 @@ set -e
 # Checkout specifically the gh-pages branch, so we can push our docs to it
 git clone -b gh-pages --single-branch git@github.com:IBM/fhe-toolkit-linux.git
 ls
+cd fhe-toolkit-linux
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
 ./RenderMLhelibAPI.sh local/fhe-toolkit-ubuntu ./html
 

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -42,7 +42,7 @@ GIT_LOG=$(git log --since="24 hours ago" --name-only)
 echo $GIT_LOG
 
 #Check to see if the .h files or the .cpp files were changed recently otherwise do nothing
-if [[ "$GIT_LOG" == *"$H_FILES"* || "$GIT_LOG" == *"$CPP_FILES"* ]; then 
+if [[ "$GIT_LOG" == *"$H_FILES"* || "$GIT_LOG" == *"$CPP_FILES"* ]]; then 
     echo "CHANGES WERE MADE SO RE-GENERATE THE DOCS"
     # Checkout specifically the gh-pages branch, so we can push our docs to it
     git clone -b gh-pages --single-branch git@github.com:IBM/fhe-toolkit-linux.git
@@ -57,6 +57,8 @@ if [[ "$GIT_LOG" == *"$H_FILES"* || "$GIT_LOG" == *"$CPP_FILES"* ]; then
     pushd ../
     pwd
     rm -rf fhe-toolkit-linux
+else
+    echo "NO CHANGES TO CODE SO NO Need to REGENEATE DOCS"
 fi
 
 

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -35,6 +35,6 @@ git clone -b gh-pages --single-branch git@github.com:IBM/fhe-toolkit-linux.git
 ls
 cd fhe-toolkit-linux
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
-./RenderMLhelibAPI.sh local/fhe-toolkit-ubuntu ./html
+./RenderMLhelibAPI.sh local/fhe-toolkit-ubuntu ./html/test
 
 #git checkout jenkins-make-docs

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -31,10 +31,9 @@ set -u
 set -e
 
 # Checkout specifically the gh-pages branch, so we can push our docs to it
-git checkout gh-pages
-pwd
+git clone -b gh-pages git@github.com:IBM/fhe-toolkit-linux.gitpwd
 ls
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
 ./RenderMLhelibAPI.sh local/fhe-toolkit-ubuntu ./html
 
-git checkout jenkins-make-docs
+#git checkout jenkins-make-docs

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -33,4 +33,4 @@ set -e
 git checkout gh-pages
 
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
-./WriteMLHElibAPIDocs local/fhe-toolkit-ubuntu ./html
+git restore master WriteMLHElibAPIDocs local/fhe-toolkit-ubuntu ./html

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -33,5 +33,6 @@ set -e
 # Checkout specifically the gh-pages branch, so we can push our docs to it
 git checkout gh-pages
 pwd
+ls
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
 ./WriteMLHElibAPIDocs.sh local/fhe-toolkit-ubuntu ./html

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -36,3 +36,5 @@ pwd
 ls
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
 ./WriteMLHElibAPIDocs.sh local/fhe-toolkit-ubuntu ./html
+
+git checkout jenkins-make-docs

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -31,7 +31,7 @@ set -u
 set -e
 
 # Checkout specifically the gh-pages branch, so we can push our docs to it
-git clone -b gh-pages git@github.com:IBM/fhe-toolkit-linux.gitpwd
+git clone -b gh-pages --single-branch git@github.com:IBM/fhe-toolkit-linux.git
 ls
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
 ./RenderMLhelibAPI.sh local/fhe-toolkit-ubuntu ./html

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -33,4 +33,4 @@ set -e
 git checkout gh-pages
 
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
-git restore jenkins-make-docs WriteMLHElibAPIDocs local/fhe-toolkit-ubuntu ./html
+git restore jenkins-make-docs WriteMLHElibAPIDocs.sh local/fhe-toolkit-ubuntu ./html

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -33,4 +33,6 @@ set -e
 git checkout gh-pages
 
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
-git restore jenkins-make-docs WriteMLHElibAPIDocs.sh local/fhe-toolkit-ubuntu ./html
+git restore jenkins-make-docs WriteMLHElibAPIDocs.sh 
+
+./WriteMLHElibAPIDocs.sh local/fhe-toolkit-ubuntu ./html

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -24,7 +24,7 @@
 # SOFTWARE.
 
 # Navigate to the top level of the Repo
-pushd ../docs
+pushd ../../
 set -x 
 set -u
 set -e
@@ -33,6 +33,4 @@ set -e
 git checkout gh-pages
 
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
-git restore jenkins-make-docs WriteMLHElibAPIDocs.sh 
-
 ./WriteMLHElibAPIDocs.sh local/fhe-toolkit-ubuntu ./html

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -25,12 +25,13 @@
 
 # Navigate to the top level of the Repo
 pushd ../../
+pwd
 set -x 
 set -u
 set -e
 
 # Checkout specifically the gh-pages branch, so we can push our docs to it
 git checkout gh-pages
-
+pwd
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
 ./WriteMLHElibAPIDocs.sh local/fhe-toolkit-ubuntu ./html

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -35,6 +35,6 @@ git clone -b gh-pages --single-branch git@github.com:IBM/fhe-toolkit-linux.git
 ls
 cd fhe-toolkit-linux
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
-./RenderMLhelibAPI.sh local/fhe-toolkit-ubuntu ./html/test
+./RenderMLhelibAPI.sh local/fhe-toolkit-ubuntu html
 
 #git checkout jenkins-make-docs

--- a/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
+++ b/scripts/jenkins/fhe_docker_jenkins_write_docs_script.sh
@@ -35,6 +35,6 @@ git checkout gh-pages
 pwd
 ls
 #Call Write ML Helib Api Docs script so we generate docs and write them to the html folder
-./WriteMLHElibAPIDocs.sh local/fhe-toolkit-ubuntu ./html
+./RenderMLhelibAPI.sh local/fhe-toolkit-ubuntu ./html
 
 git checkout jenkins-make-docs


### PR DESCRIPTION
Script for jenkins to generate the docs and push them to a special `gh-pages` branch in our git repository.  Checks the git commits to see if any `.h` or `.cpp` files have been changed and if so, runs the render docs script