### PR TITLE
Added all examples to vscode cmake, removed tutorial

### DIFF
--- a/Dockerfile.CENTOS-amd64.Toolkit
+++ b/Dockerfile.CENTOS-amd64.Toolkit
@@ -15,7 +15,8 @@ USER root
 WORKDIR /root
 
 # Install code-server so we can access the IDE from a container context...
-RUN curl -fsSL https://code-server.dev/install.sh | sh 2>&1
+#RUN curl -fsSL https://code-server.dev/install.sh | sh 2>&1
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 3.9.1 2>&1
 #Install cpptools from the latest vsix version which we are pinning to becuase we have issues getting it to install normally - 12.03.2020 - greg
 ADD https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix /opt/IBM/FHE-Workspace/
 

--- a/Dockerfile.FEDORA-amd64.Toolkit
+++ b/Dockerfile.FEDORA-amd64.Toolkit
@@ -15,7 +15,8 @@ USER root
 WORKDIR /root
 
 # Install code-server so we can access the IDE from a container context...
-RUN curl -fsSL https://code-server.dev/install.sh | sh 2>&1
+#RUN curl -fsSL https://code-server.dev/install.sh | sh 2>&1
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 3.9.1 2>&1
 #Install cpptools from the latest vsix version which we are pinning to becuase we have issues getting it to install normally - 12.03.2020 - greg
 ADD https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix /opt/IBM/FHE-Workspace/
 

--- a/Dockerfile.FEDORA-s390x.Toolkit
+++ b/Dockerfile.FEDORA-s390x.Toolkit
@@ -36,7 +36,7 @@ RUN cp -pr ./node-v12.18.2-linux-s390x/bin     \
 
 # Install code-server so we can access vscode from a container context...
 #RUN curl -fsSL https://code-server.dev/install.sh | sh 2>&1
-RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 3.9.1 2>&1
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 3.9.1
 
 # Create a directory to hold the VSCode user data when running as root
 RUN mkdir -p /opt/IBM/IDE-Data

--- a/Dockerfile.FEDORA-s390x.Toolkit
+++ b/Dockerfile.FEDORA-s390x.Toolkit
@@ -35,7 +35,8 @@ RUN cp -pr ./node-v12.18.2-linux-s390x/bin     \
            /usr/local
 
 # Install code-server so we can access vscode from a container context...
-RUN curl -fsSL https://code-server.dev/install.sh | sh 2>&1
+#RUN curl -fsSL https://code-server.dev/install.sh | sh 2>&1
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 3.9.1 2>&1
 
 # Create a directory to hold the VSCode user data when running as root
 RUN mkdir -p /opt/IBM/IDE-Data

--- a/Dockerfile.UBUNTU-amd64.Toolkit
+++ b/Dockerfile.UBUNTU-amd64.Toolkit
@@ -18,7 +18,9 @@ WORKDIR /root
 RUN export DEBIAN_FRONTEND=noninteractive
 
 # Install code-server so we can access the IDE from a container context...
-RUN curl -fsSL https://code-server.dev/install.sh | sh
+#RUN curl -fsSL https://code-server.dev/install.sh | sh
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 3.9.1
+
 #Install cpptools from the latest vsix version which we are pinning to becuase we have issues getting it to install normally - 12.03.2020 - greg
 ADD https://github.com/microsoft/vscode-cpptools/releases/download/1.1.2/cpptools-linux.vsix /opt/IBM/FHE-Workspace/
 

--- a/Dockerfile.UBUNTU-s390x.Toolkit
+++ b/Dockerfile.UBUNTU-s390x.Toolkit
@@ -36,7 +36,8 @@ RUN cp -pr ./node-v12.18.2-linux-s390x/bin     \
            /usr/local
 
 # Install code-server so we can access vscode from a container context...
-RUN curl -fsSL https://code-server.dev/install.sh | sh 2>&1
+#RUN curl -fsSL https://code-server.dev/install.sh | sh 2>&1
+RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --version 3.9.1 2>&1
 
 # Create a directory to hold the VSCode user data when running as root
 RUN mkdir -p /opt/IBM/IDE-Data

--- a/IDE_Config/settings.json
+++ b/IDE_Config/settings.json
@@ -1,6 +1,6 @@
 {
     "terminal.integrated.shell.linux": "/usr/bin/bash",
-    "cmake.sourceDirectory": "${workspaceFolder}/examples/BGV_world_country_db_lookup",
+    "cmake.sourceDirectory": "${workspaceFolder}/examples",
     "cmake.configureOnOpen": true,
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools"
 }

--- a/samples/BGV_world_country_db_lookup/CMakeLists.txt
+++ b/samples/BGV_world_country_db_lookup/CMakeLists.txt
@@ -24,7 +24,7 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-project(BGV_world_country_db_lookup VERSION 0.0.1 LANGUAGES CXX)
+project(1-PrivacyPreservingKeyValueSearch-BGV VERSION 0.0.1 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_CXX_FLAGS "-Werror -fopenmp -Wfatal-errors")
@@ -37,5 +37,5 @@ find_package(Boost 1.72.0 EXACT REQUIRED COMPONENTS filesystem system thread)
 find_package(HDF5 REQUIRED COMPONENTS CXX)
 include_directories(${HDF5_INCLUDE_DIR})
 
-add_executable(BGV_world_country_db_lookup BGV_world_country_db_lookup.cpp)
-target_link_libraries(BGV_world_country_db_lookup mlhelib helib ${Boost_LIBRARIES})
+add_executable(1-PrivacyPreservingKeyValueSearch-BGV BGV_world_country_db_lookup.cpp)
+target_link_libraries(1-PrivacyPreservingKeyValueSearch-BGV mlhelib helib ${Boost_LIBRARIES})

--- a/samples/CKKS_credit_card_fraud/CMakeLists.txt
+++ b/samples/CKKS_credit_card_fraud/CMakeLists.txt
@@ -24,7 +24,7 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-project(CKKS_credit_card_fraud VERSION 0.0.1 LANGUAGES CXX)
+project(2-CreditCardFraudDetectionInferencing-CKKS VERSION 0.0.1 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_BUILD_TYPE Release)
 set(CMAKE_CXX_FLAGS "-Werror -fopenmp -Wfatal-errors")
@@ -37,5 +37,5 @@ find_package(Boost 1.72.0 EXACT REQUIRED COMPONENTS filesystem system thread)
 find_package(HDF5 REQUIRED COMPONENTS CXX)
 include_directories(${HDF5_INCLUDE_DIR})
 
-add_executable(CKKS_credit_card_fraud CKKS_credit_card_fraud_helib.cpp ClientServer.cpp)
-target_link_libraries(CKKS_credit_card_fraud mlhelib helib ${HDF5_LIBRARIES} ${Boost_LIBRARIES})
+add_executable(2-CreditCardFraudDetectionInferencing-CKKS CKKS_credit_card_fraud_helib.cpp ClientServer.cpp)
+target_link_libraries(2-CreditCardFraudDetectionInferencing-CKKS mlhelib helib ${HDF5_LIBRARIES} ${Boost_LIBRARIES})

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,0 +1,51 @@
+# Copyright (C) 2020 IBM Corp.
+# This program is Licensed under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#   http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License. See accompanying LICENSE file.
+
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+
+## Use -std=c++17 as default.
+set(CMAKE_CXX_STANDARD 17)
+## Disable C++ extensions
+set(CMAKE_CXX_EXTENSIONS OFF)
+## Require full C++ standard
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_CXX_FLAGS "-Werror -fopenmp -Wfatal-errors")
+
+# Define standard installation directories (GNU)
+include(GNUInstallDirs)
+
+# Set default output folder
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY
+    "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")
+
+
+
+## Rely on the Environment variable to dictate which version of helib to use
+set(HELIB_VERSION ${HELIB_CMAKE_LISTS_VERSON})
+
+find_package(helib ${HELIB_VERSION} REQUIRED)
+find_package(Boost 1.72.0 EXACT REQUIRED COMPONENTS filesystem system thread)
+find_package(HDF5 REQUIRED COMPONENTS CXX)
+include_directories(${HDF5_INCLUDE_DIR})
+
+add_subdirectory(BGV_binary_arithmetic)
+add_subdirectory(BGV_world_country_db_lookup)
+add_subdirectory(BGV_packed_arithmetic)
+# add_subdirectory(tutorial)
+add_subdirectory(CKKS_credit_card_fraud)


### PR DESCRIPTION
Now when launching the vscode server, after selecting the desired kit, you can build all examples using the build button, and select an example to run using the play button. The `tutorial` examples were removed for simplicity but can be built manually.