### PR TITLE
Added a more informative error message when unable to init cr

### DIFF
--- a/automation/DeployToHPVS.bashlib
+++ b/automation/DeployToHPVS.bashlib
@@ -1216,7 +1216,7 @@ init_repo_for_notary_server(){
     # Initiate repository in remote notary push delegation key
     run_command "${runcmd}"
     if [[ $? != 0 ]]; then
-        fatal_error "Failed to initiate repository '${5}' in notary"
+        fatal_error "Failed to initiate repository '${5}' in notary \nYou will get this message if your cloud plan is over the alloted storage space in the container registry. \nPlease check using 'ibmcloud cr images' command in the cli to verify you are still under your quota."
     else
         write_success "Initiated repository '${5}' in notary, and added '${4}' as a delegation key"
     fi


### PR DESCRIPTION
Instead of simply passing on an unhelpful error, if the deploy script fails on the container repository initialization step, a message is printed explaining it could be due to being out of storage on a free account, and provides the command to check if one has existing containers on HPVS causing the error.

addresses https://github.com/IBM/fhe-toolkit-linux/issues/152
