### PR TITLE
bug-fix: first-interaction greeting

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [pull_request, issues]
+on: [pull_request_target, issues]
 
 jobs:
   greeting:


### PR DESCRIPTION
Use `pull_request_target` instead of `pull_request` to hopefully fix the problem where the first-interaction greeting fails because of inadequate permissions to add a message on the PR. Resolves #182 