### PR TITLE
Pull helayers from IBM Container Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ For the C++ version:
 
 The script will pull & download the latest version that works on your machine's architecture. It will run locally in its own container for you to view in your web browser.  The script will tell you where to point your browser to in the Terminal after completing the setup. The c++ version uses VSCode integrated into the browser for an IDE, using port 8443, and the python relies on a self-contained jupyter notebook on port 8888.
 
-To try HELayers out from Dockerhub directly, you can use these links below:
+To try HELayers out from the IBM Container Registry directly, follow the instructions below:
 
 * Python
-   * [HELayers Python x86](https://hub.docker.com/r/ibmcom/helayers-pylab)
-   * [HELayers Python s390x](https://hub.docker.com/r/ibmcom/helayers-pylab-s390x)
+   * [HELayers Python x86](https://ibm.github.io/helayers/pylab/)
+   * [HELayers Python s390x](https://ibm.github.io/helayers/pylab-s390x/)
 * C++
-   * [HELayers C++ x86](https://hub.docker.com/r/ibmcom/helayers-lab)
-   * [HELayers C++ s390x](https://hub.docker.com/r/ibmcom/helayers-lab-s390x)
+   * [HELayers C++ x86](https://ibm.github.io/helayers/lab/)
+   * [HELayers C++ s390x](https://ibm.github.io/helayers/lab-s390x/)
 
 ### Take a look at our in-depth walkthrough video on how to download and get started with HElayers.
 

--- a/StartHELayers.sh
+++ b/StartHELayers.sh
@@ -41,7 +41,7 @@ print_usage(){
   ${bold}Usage: $SCRIPTNAME [options] LAB_TYPE${normal}
 
   ${bold}LAB_TYPE${normal}   Selects the type of lab to
-                 download the HELayers container from Docker Hub.
+                 download the HELayers container from IBM Container Registry.
                  Available lab types are:
                  x86_64/amd64: {cpp, python}
                  s390x:        {cpp, python}
@@ -148,6 +148,7 @@ else
   fi
 fi
 
+image="icr.io/helayers/helayers-$imagesuffix:latest"
 
 ################################################################
 # The script has the following arguments:
@@ -173,19 +174,18 @@ echo " Lab: $labtype "
 echo ""
 echo "==============================================================="
 
-docker pull ibmcom/helayers-$imagesuffix
-docker tag ibmcom/helayers-$imagesuffix ibmcom/helayers-$imagesuffix
+docker pull "$image"
 if [ $? -ne 0 ]; then
   echo " "
-  echo " FATAL: Aborting. There was an issue pulling the image ibmcom/helayers-$imagesuffix "
+  echo " FATAL: Aborting. There was an issue pulling the image $image"
   echo " "
   exit -1
 fi
 
-docker run -p $labport:$labport -d --rm --name helayers-$imagesuffix ibmcom/helayers-$imagesuffix:latest
+docker run -p $labport:$labport -d --rm --name helayers-$imagesuffix "$image"
 if [ $? -ne 0 ]; then
   echo " "
-  echo " FATAL: Aborting. There was an issue running the image ibmcom/helayers-$imagesuffix "
+  echo " FATAL: Aborting. There was an issue running the image $image"
   echo " "
   exit -1
 fi


### PR DESCRIPTION
The official storage for helayers is moving from Docker Hub to IBM Container Registry (icr.io).  Modify the links and scripts accordingly.

Signed-off-by: Dov Murik <dov.murik1@il.ibm.com>